### PR TITLE
IDs as keys

### DIFF
--- a/src/components/campaign/CampaignForm.jsx
+++ b/src/components/campaign/CampaignForm.jsx
@@ -64,7 +64,7 @@ export default class CampaignForm extends React.Component {
 
             let dayComponents = actionsByDay.toList().map((actions, key) => {
                 // TODO: Do more logic to group actions as shifts et c
-                let actionComponents = actions.map(action => {
+                let actionComponents = actions.toList().map(action => {
                     let response = !!responseList.get('items').find(item =>
                         item.get('action_id') == action.get('id'));
 

--- a/src/components/dashboard/ActionList.jsx
+++ b/src/components/dashboard/ActionList.jsx
@@ -43,7 +43,7 @@ export default class ActionList extends React.Component {
             return (
                 <div className="ActionList">
                     <ul>
-                    { actions.map(item => (
+                    { actions.toList().map(item => (
                         <ActionListItem key={ item.get('id') }
                             action={ item }/>
                     ))}

--- a/src/components/dashboard/AssignmentList.jsx
+++ b/src/components/dashboard/AssignmentList.jsx
@@ -44,7 +44,7 @@ export default class AssignmentList extends React.Component {
             return (
                 <div className="AssignmentList">
                     <ul>
-                    { assignments.map(item => (
+                    { assignments.toList().map(item => (
                         <AssignmentListItem key={ item.get('id') }
                             assignment={ item }/>
                     ))}

--- a/src/components/dashboard/CampaignList.jsx
+++ b/src/components/dashboard/CampaignList.jsx
@@ -45,7 +45,7 @@ export default class CampaignList extends React.Component {
             return (
                 <div className="CampaignList">
                     <ul>
-                    { campaigns.map(item => (
+                    { campaigns.toList().map(item => (
                         <CampaignListItem key={ item.get('id') }
                             campaign={ item }/>
                     ))}

--- a/src/store/callAssignments.js
+++ b/src/store/callAssignments.js
@@ -26,11 +26,15 @@ export default createReducer(initialState, {
     },
 
     [RETRIEVE_USER_ASSIGNMENTS + '_FULFILLED']: (state, action) => {
-        let assignments = action.payload.data.data;
+        let assignments = {};
+        action.payload.data.data.forEach(assignment =>
+            assignments[assignment.id] = assignment);
 
         return state
             .setIn(['assignmentList', 'error'], null)
             .setIn(['assignmentList', 'isPending'], false)
-            .setIn(['assignmentList', 'items'], immutable.fromJS(assignments));
+            .updateIn(['assignmentList', 'items'], items => items?
+                items.merge(immutable.fromJS(assignments)) :
+                immutable.fromJS(assignments));
     },
 });

--- a/src/store/orgs.js
+++ b/src/store/orgs.js
@@ -29,20 +29,29 @@ export default createReducer(initialState, {
     },
 
     [types.RETRIEVE_USER_MEMBERSHIPS + '_FULFILLED']: (state, action) => {
-        let orgs = action.payload.data.data;
+        let memberships = {};
+
+        action.payload.data.data.forEach(membership =>
+            memberships[membership.organization.id] = membership);
 
         return state
             .setIn(['membershipList', 'error'], null)
             .setIn(['membershipList', 'isPending'], false)
-            .setIn(['membershipList', 'items'], immutable.fromJS(orgs));
+            .updateIn(['membershipList', 'items'], items => items?
+                items.merge(immutable.fromJS(memberships)) :
+                immutable.fromJS(memberships));
     },
 
     [types.RETRIEVE_ALL_ACTIONS + '_FULFILLED']: (state, action) => {
-        // TODO: Merge instead of replacing?
-        let orgs = action.payload.map(res => res.meta.org);
+        let orgs = {};
+        action.payload.forEach(res =>
+            orgs[res.meta.org.id] = res.meta.org);
+
         return state
             .setIn(['orgList', 'error'], null)
             .setIn(['orgList', 'isPending'], false)
-            .setIn(['orgList', 'items'], immutable.fromJS(orgs));
+            .updateIn(['orgList', 'items'], items => items?
+                items.merge(immutable.fromJS(orgs)) :
+                immutable.fromJS(orgs));
     }
 });


### PR DESCRIPTION
This PR migrates all stores to use IDs as keys, which allows for easier look-ups and merging old state with new results from retrievals.

Closes #13