### PR TITLE
Registration without browser JS

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -52,8 +52,6 @@ export default function initApp(messages) {
     app.get('/', auth.callback(authOpts));
     app.get('/logout', auth.logout(authOpts));
 
-    app.post('/forms/actionResponse', auth.validate(authOpts), formEndpoints.actionResponse);
-
     app.get('/l10n', loadLocaleHandler());
 
     // Require authentication for some routes
@@ -61,6 +59,9 @@ export default function initApp(messages) {
     app.get('/settings', auth.validate(authOpts));
 
     app.use(preloader(messages));
+
+    app.post('/forms/actionResponse', auth.validate(authOpts), formEndpoints.actionResponse);
+    app.post('/register', formEndpoints.register);
 
     // TODO: Better way of handling 404s
     app.use('/o/:org_id/campaigns/:campaign_id', (req, res, next) => {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -52,7 +52,7 @@ export default function initApp(messages) {
     app.get('/', auth.callback(authOpts));
     app.get('/logout', auth.logout(authOpts));
 
-    app.use('/forms', auth.validate(authOpts), formEndpoints);
+    app.post('/forms/actionResponse', auth.validate(authOpts), formEndpoints.actionResponse);
 
     app.get('/l10n', loadLocaleHandler());
 

--- a/src/server/forms/index.js
+++ b/src/server/forms/index.js
@@ -1,13 +1,5 @@
-import express from 'express';
-import bodyParser from 'body-parser';
-
 import actionResponse from './actionResponse';
 
-
-const router = express();
-
-// TODO: Implement CSRF handling
-router.use(bodyParser.urlencoded({ extended: true }));
-router.post('/actionResponse', actionResponse);
-
-export default router;
+export default {
+    actionResponse,
+}

--- a/src/server/forms/index.js
+++ b/src/server/forms/index.js
@@ -1,5 +1,6 @@
 import actionResponse from './actionResponse';
+import register from './register';
 
 export default {
-    actionResponse,
+    actionResponse, register,
 }

--- a/src/server/forms/register.js
+++ b/src/server/forms/register.js
@@ -1,0 +1,47 @@
+'use strict';
+
+import { REGISTER } from '../../actions';
+
+
+export default (req, res, next) => {
+    let form = req.body;
+    let data = {
+        first_name: form.fn,
+        last_name: form.ln,
+        email: form.email,
+        password: form.password,
+    };
+
+    let meta = {
+        firstName: data.first_name,
+        lastName: data.last_name,
+        email: data.email,
+    };
+
+    req.store.dispatch({
+        type: REGISTER + '_PENDING',
+        meta: meta,
+    });
+
+    req.z.resource('users')
+        .post(data)
+        .then(result => {
+            req.store.dispatch({
+                type: REGISTER + '_FULFILLED',
+                meta: meta,
+                payload: result,
+            });
+
+            next();
+        })
+        .catch(err => {
+            console.log('error', err);
+            req.store.dispatch({
+                type: REGISTER + '_REJECTED',
+                meta: meta,
+                payload: err,
+            });
+
+            next();
+        })
+};


### PR DESCRIPTION
This PR fixes an undocumented bug (or rather, lack of feature) making it impossible to register without JS support. At least one user has experienced this issue. The reason why javascript wasn't working is unknown, but registration without JS should be enabled regardless.