### PR TITLE
Intl polyfill for Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^2.0.0",
     "immutable": "^3.8.1",
+    "intl": "^1.2.5",
     "node-yaml": "^3.0.2",
     "object-subset": "0.0.4",
     "react": "^15.3.2",

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -1,5 +1,9 @@
 require('array.prototype.find');
 
+require('intl');
+require('intl/locale-data/jsonp/en.js');
+require('intl/locale-data/jsonp/sv.js');
+
 // Extend standard Date API using sugar-date
 require('sugar-date').Date.extend();
 


### PR DESCRIPTION
This PR adds the Intl polyfill for Safari (and other browsers not supporting the `Intl` framework).

Fixes #93