### PR TITLE
Warning on dev server

### DIFF
--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -1,3 +1,8 @@
+environmentWarning:
+    message: >-
+        Detta är en utvecklingsversion av Zetkin. Du vill antagligen använda
+        verkliga Zetkin på www.zetk.in. Vill du navigera dit nu?
+
 welcome:
     header: "Välkommen till Min sida"
     notConnected: "Du är inte ansluten till någon organisation."

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,13 +1,26 @@
-import { connect } from 'react-redux';
 import React from 'react';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
 
 import Footer from './Footer';
 import GoogleAnalytics from './misc/GoogleAnalytics';
 import Header from './header/Header';
 
 
+@injectIntl
 @connect(state => ({ fullState: state }))
 export default class App extends React.Component {
+    componentDidMount() {
+        if (location.hostname.indexOf('dev.zetkin.org') >= 0) {
+            let msg = this.props.intl.formatMessage(
+                { id: 'misc.environmentWarning.message' });
+
+            if (confirm(msg)) {
+                location = '//www.zetk.in' + location.pathname;
+            }
+        }
+    }
+
     render() {
         let path = this.props.location.pathname;
         let stateJson = JSON.stringify(this.props.fullState);


### PR DESCRIPTION
This PR adds a very simple warning on the dev server, alerting users that they're on the development version of Zetkin and should probably be using the real version. Clicking OK on the warning takes the user to the same page on production Zetkin.

Fixes #99 