### PR TITLE
Select widgets in survey questions

### DIFF
--- a/src/components/surveyForm/widgets/OptionsWidget.jsx
+++ b/src/components/surveyForm/widgets/OptionsWidget.jsx
@@ -14,28 +14,49 @@ export default class OptionsWidget extends React.Component {
         let question = this.props.question;
         let type = question.getIn(['response_config', 'widget_type']) || 'radio';
 
-        let optionItems = question.get('options').map(option => {
-            let id = option.get('id');
+        if (type == 'select') {
+            let optionItems = question.get('options').map(opt => {
+                let id = opt.get('id');
+
+                return (
+                    <option key={ id } value={ id }>
+                        { opt.get('text') }
+                    </option>
+                );
+            });
 
             return (
-                <li key={ id }>
-                    <input type={ type } value={ id }
-                        name={ name + '.options' }
-                        id={ 'option-' + id }
-                        />
-                    <label htmlFor={ 'option-' + id }>
-                        { option.get('text') }
-                    </label>
-                </li>
+                <div className="OptionsWidget">
+                    <select name={ name + '.options' }>
+                        { optionItems }
+                    </select>
+                </div>
             );
-        });
+        }
+        else {
+            let optionItems = question.get('options').map(option => {
+                let id = option.get('id');
 
-        return (
-            <div className="OptionsWidget">
-                <ul>
-                    { optionItems }
-                </ul>
-            </div>
-        );
+                return (
+                    <li key={ id }>
+                        <input type={ type } value={ id }
+                            name={ name + '.options' }
+                            id={ 'option-' + id }
+                            />
+                        <label htmlFor={ 'option-' + id }>
+                            { option.get('text') }
+                        </label>
+                    </li>
+                );
+            });
+
+            return (
+                <div className="OptionsWidget">
+                    <ul>
+                        { optionItems }
+                    </ul>
+                </div>
+            );
+        }
     }
 }


### PR DESCRIPTION
Add support for `select` widgets in survey rendering. Some legacy surveys have this configuration even though there is no support for it in Organize yet (see zetkin/organize.zetk.in#499).