### PR TITLE
Survey privacy approval

### DIFF
--- a/locale/surveyForm/en.yaml
+++ b/locale/surveyForm/en.yaml
@@ -1,3 +1,13 @@
+privacy:
+    h: Accept the terms
+    label: I accept the terms outlined below
+    p: |-
+        When you submit this survey, the information you provide will be stored
+        and processed in Zetkin by {org} in order to organize activism and in
+        accordance with the Zetkin privacy policy.
+    policyLink:
+        label: Read the full Zetkin Privacy Policy
+        href: http://zetkin.org/privacy
 signature:
     h: Choose how to sign
     options:

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -32,8 +32,9 @@ export default class App extends React.Component {
 
         if (this.props.params.orgId) {
             let org = organization(this.props.fullState, this.props.params.orgId);
-
-            title = org.get('title') + ' | ' + title;
+            if (org) {
+                title = org.get('title') + ' | ' + title;
+            }
         }
 
         return (

--- a/src/server/forms/survey.js
+++ b/src/server/forms/survey.js
@@ -22,6 +22,9 @@ export default (req, res, next) => {
         if (name.indexOf('sig') == 0) {
             continue;
         }
+        else if (name.indexOf('privacy') == 0) {
+            continue;
+        }
 
         let fields = name.split('.');
         let q_id = fields[0];

--- a/src/server/preloader.js
+++ b/src/server/preloader.js
@@ -62,6 +62,7 @@ export default (messages) => {
     ]));
 
     preloader.get('/o/:orgId/surveys/:surveyId', waitForActions(req => [
+        retrieveOrganization(req.params.orgId),
         retrieveSurvey(req.params.orgId, req.params.surveyId),
     ]));
 

--- a/src/store/orgs.js
+++ b/src/store/orgs.js
@@ -3,9 +3,13 @@ import immutable from 'immutable';
 
 import * as types from '../actions';
 
-export const organization = (state, id) =>
-    state.getIn(['orgs', 'orgList', 'items', id.toString()]) ||
-    state.getIn(['orgs', 'orgList', 'items']).find(o => o.get('slug') == id.toString());
+export const organization = (state, id) => {
+    let items = state.getIn(['orgs', 'orgList', 'items']);
+    if (items) {
+        return items.get(id.toString()) || items.find(o => o.get('slug') == id.toString());
+    }
+    else return null;
+}
 
 const initialState = immutable.fromJS({
     orgList: {


### PR DESCRIPTION
This PR updates to the most recent version of zetkin-common which includes a privacy approval checkbox at the end of `SurveyForm`, and adds the necessary server-side form processing and strings.

It also fixes a crash bug on `SurveyPage` introduced by #177.