### PR TITLE
Header.scss: spelling of mixin name

### DIFF
--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -31,11 +31,11 @@
         margin: 0.5em;
 
         &.linkOrganize {
-            @include icon-button($fa-var-sitemap);
+            @include icon-button-add($fa-var-sitemap);
         }
 
         &.linkCall {
-            @include icon-button($fa-var-phone);
+            @include icon-button-add($fa-var-phone);
         }
     }
 }


### PR DESCRIPTION
This PR updates the name of an SCSS mixin in a usage which otherwise fails the `bin/build_dev`.