### PR TITLE
Use CampaignForm activityFilter except on "My Actions" tab of Dashboard

### DIFF
--- a/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
+++ b/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
@@ -104,6 +104,7 @@ export default class CampaignSectionPage extends SectionPage {
                 onSelect={ this.onTabSelect.bind(this) }
             />,
             <CampaignForm key="campaignForm"
+                needActivityFilter={ selectedTab !== 'signed' }
                 orgList={ this.props.orgList.get('items') }
                 redirPath={ this.props.redirPath }
                 actionList={ scopedActionList }

--- a/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
+++ b/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
@@ -104,7 +104,7 @@ export default class CampaignSectionPage extends SectionPage {
                 onSelect={ this.onTabSelect.bind(this) }
             />,
             <CampaignForm key="campaignForm"
-                needActivityFilter={ selectedTab !== 'signed' }
+                activityFilter={ selectedTab !== 'signed' }
                 orgList={ this.props.orgList.get('items') }
                 redirPath={ this.props.redirPath }
                 actionList={ scopedActionList }


### PR DESCRIPTION
This PR uses the brand-new prop `needActivityFilter` seen in the zetkin-common PR below.

It hides the Activity Filter widget if we're on the _My Actions_ tab.

See https://github.com/zetkin/www.zetk.in/issues/246

Depends on: https://github.com/zetkin/zetkin-common/pull/43

Here's what it looks like on a Campaign Page (no change):

<img width="377" alt="image" src="https://user-images.githubusercontent.com/211/44099077-19f4c808-9fe2-11e8-8bd1-079110021997.png">

And here, the changed thing, on the "My Actions" tab, we do not display it:

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/211/44099187-65110874-9fe2-11e8-8933-64431cd5a247.png">
