### PR TITLE
Use key to separate all/my action lists on dashboard

### DIFF
--- a/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
+++ b/src/components/pages/dashboard/sections/CampaignSectionPage.jsx
@@ -103,7 +103,7 @@ export default class CampaignSectionPage extends SectionPage {
                 selected={ selectedTab }
                 onSelect={ this.onTabSelect.bind(this) }
             />,
-            <CampaignForm key="campaignForm"
+            <CampaignForm key={ selectedTab }
                 activityFilter={ selectedTab !== 'signed' }
                 orgList={ this.props.orgList.get('items') }
                 redirPath={ this.props.redirPath }


### PR DESCRIPTION
This PR fixes #288 by making sure that the `CampaignForm` component used under both tabs on the dashboard is remounted for each tab, so that state is reset.