### PR TITLE
Follow when signing up to an organization which is not followed.

### DIFF
--- a/src/server/ops.js
+++ b/src/server/ops.js
@@ -46,7 +46,16 @@ const OPS = {
                     const membership = result.data.data.find(m => m.organization.id == orgId);
 
                     if (membership) {
-                        return membership.profile.id;
+                        // Make sure the is following the relevant organization
+                        if (membership.follow) {
+                            return membership.profile.id;
+                        } else {
+                            return req.z.resource('users', 'me', 'following', orgId)
+                                .put()
+                                .then(followResult => {
+                                    return membership.profile.id;
+                                });
+                        }
                     }
                     else {
                         return req.z.resource('orgs', orgId, 'join_requests')


### PR DESCRIPTION
Fixes bug where a user signs up to a connected but not followed organization, such as a parent organization.

Follow these steps to verify the fix:
1. Set follow=false to a membership, e.g. `update members_person_organizations set follow = false where organization_id = 1 and person_id = 2;`
2. Log in using the account (`testadmin@example.com `in this case) and visit a public campaign from the unfollowed campaign, e.g. http://www.dev.zetkin.org/o/1/campaigns/2
3. Sign up to an action and click to connect.
4. Go to "My actions"

Before the fix: The signed up action is not visible because the user does not follow the organization.
After the fix: The signed up action is visible.