### PR TITLE
Increase opacity of signup form labels to accessible levels

### DIFF
--- a/src/components/misc/SignUpForm.scss
+++ b/src/components/misc/SignUpForm.scss
@@ -100,7 +100,7 @@
     font-size: 0.7em;
     margin-left: 1.2em;
     margin-top: 0.5em;
-    color: lighten($c-text, 30);
+    color: $c-text;
     opacity: 1;
 
     @include target-ie-6-7-8 {
@@ -131,7 +131,7 @@
     display: inline-block;
     font-size: 0.8em;
     margin-top: 1em;
-    color: lighten($c-text, 30);
+    color: $c-text;
     opacity: 1;
 
     &:before {


### PR DESCRIPTION
Hey there! I've just recently started using zetkin and got excited to contribute some accessibility improvements to it. Here's a nice simple one to see how I get on!

The `lighten()` call here is reducing the contrast of the signup form input field labels to the point where people with low vision will struggle to read them. It's setting them to `#999999`, which has a contrast ratio of 2.86 against the white background. Removing the `lighten()` call changes it to `#5C5C5C`, which gives a nice big 6.69 contrast ratio!

| Before | After |
|-|-|
| ![Signup form with low contrast on input field labels](https://user-images.githubusercontent.com/566159/191100398-489cfef6-3672-41fe-9f58-1adcf0ce5d87.png) | ![Signup form with increased label contrast](https://user-images.githubusercontent.com/566159/191100472-6cf8f0f9-77b1-46d4-a3b2-7558fd202de1.png)

I've been doing some poking around and have noticed you're all super focused on the Generation 3 work right now so maybe this is outside your priorities for the moment and I'd understand that! But if you have time to take a look then this kind of small change would make a big difference for potential activists who have limited vision!