### PR TITLE
Move build to first run

### DIFF
--- a/env/app/Dockerfile
+++ b/env/app/Dockerfile
@@ -37,7 +37,6 @@ RUN npm install
 ENV NODE_ICU_DATA node_modules/full-icu
 
 COPY . ./
-RUN npm install --unsafe-perm
 
 # Init
 

--- a/env/app/run.sh
+++ b/env/app/run.sh
@@ -4,6 +4,7 @@ cd /var/app
 
 if [ "$NODE_ENV" == "production" ]
 then
+    npm install --unsafe-perm
     node build/app/server/main
 else
     ./node_modules/.bin/concurrently \


### PR DESCRIPTION
This PR moves the building of frontend code to runtime, instead of the docker build. This is so that a single image built from the code in this repo can be used in multiple environments.