### PR TITLE
Undocumented survey select widget bugs

### DIFF
--- a/locale/surveyForm/en.yaml
+++ b/locale/surveyForm/en.yaml
@@ -8,6 +8,8 @@ privacy:
     policyLink:
         href: 'http://zetkin.org/privacy'
         label: Click to read the full Zetkin Privacy Policy
+select:
+    default: Pick an option
 signature:
     h: Choose how to sign
     options:

--- a/src/server/forms/survey.js
+++ b/src/server/forms/survey.js
@@ -38,10 +38,10 @@ export default (req, res, next) => {
 
         if (type == 'options') {
             if (Array.isArray(form[name])) {
-                responses[q_id].options = form[name].map(o => parseInt(o));
+                responses[q_id].options = form[name].map(o => parseInt(o)).filter(id => !!id);
             }
             else {
-                responses[q_id].options = [ parseInt(form[name]) ];
+                responses[q_id].options = [ parseInt(form[name]) ].filter(id => !!id);
             }
         }
         else if (type == 'text') {


### PR DESCRIPTION
This PR fixes two issues with the "select" widget for multi-choice survey questions.

* The default text was missing from the English strings (and hence all translations)
* If the user didn't pick an option, it would result in `[null]` being sent to the server, which is invalid and would cause the entire form submission to be rejected

The latter is of course a critical bug, which seems to have been introduced by zetkin/zetkin-common#59. Please help me test this thoroughly and be critical against how I've solved this.

I want to merge and deploy this today if possible, but I also want to move to the Gen3 survey interface as soon as we can, so it's not critical that the solution here is the most beautiful, as long as it feels reliable.

As far as I can tell, this only affects the activist portal (not Call) which is why I decided to solve this outside of common.